### PR TITLE
feat: add telemetry event to capture node warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
       "@salesforce/plugin-command-reference"
     ]
   },
-  "repository": "salesforcecli/plugin-template",
+  "repository": "salesforcecli/plugin-telemetry",
   "scripts": {
     "build": "sf-build",
     "clean": "sf-clean",

--- a/src/hooks/telemetryPrerun.ts
+++ b/src/hooks/telemetryPrerun.ts
@@ -42,6 +42,21 @@ const hook: Hook.Prerun = async function (options: Hooks['prerun']): Promise<voi
       config: this.config,
     });
 
+    process.on('warning', (warning) => {
+      const pluginInfo = commandExecution.getPluginInfo();
+      telemetry.record({
+        eventName: 'NODE_WARNING',
+        warningType: warning.name,
+        stack: warning.stack,
+        message: warning.message,
+        nodeVersion: process.version,
+        plugin: pluginInfo.name,
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        plugin_version: pluginInfo.version,
+        command: commandExecution.getCommandName(),
+      });
+    });
+
     debug('Setting up process exit handler');
     process.once('exit', (status) => {
       commandExecution.status = status;
@@ -52,7 +67,6 @@ const hook: Hook.Prerun = async function (options: Hooks['prerun']): Promise<voi
         // This could be from too many plugins. If we start getting this, log number of plugins too.
         telemetry.record({
           eventName: 'EVENT_EMITTER_WARNING',
-          type: 'process.exit',
           count: process.listenerCount('exit'),
         });
       }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -100,10 +100,7 @@ export default class Telemetry extends AsyncCreatable {
         if (!env.getBoolean('SFDX_TELEMETRY_DISABLE_ACKNOWLEDGEMENT', false)) {
           // eslint-disable-next-line no-console
           console.warn(
-            'You acknowledge and agree that the CLI tool may collect usage information, ' +
-              'user environment, and crash reports for the purposes of providing services or functions that are relevant ' +
-              'to use of the CLI tool and product improvements.',
-            EOL
+            `You acknowledge and agree that the CLI tool may collect usage information, user environment, and crash reports for the purposes of providing services or functions that are relevant to use of the CLI tool and product improvements.${EOL}`
           );
         }
         Telemetry.acknowledged = true;

--- a/test/hooks/telemetryPrerun.test.ts
+++ b/test/hooks/telemetryPrerun.test.ts
@@ -43,9 +43,14 @@ describe('telemetry prerun hook', () => {
     context = stubInterface<Hook.Context>(sandbox, { config });
 
     processExitStub = stubMethod(sandbox, process, 'once');
-    processCmdErrorStub = stubMethod(sandbox, process, 'on');
+    processCmdErrorStub = stubMethod(sandbox, process, 'on').withArgs('cmdError');
     createCommandStub = stubMethod(sandbox, CommandExecution, 'create').callsFake(async () => ({
       toJson: () => ({}),
+      getPluginInfo: () => ({
+        name: '@salesforce/foo',
+        version: '1.0.0',
+      }),
+      getCommandName: () => 'foo:bar',
     }));
     stubMethod(sandbox, Telemetry, 'create').callsFake(async () => {
       return {


### PR DESCRIPTION
### Description
- Captures node warnings and sends them to app insights (`salesforce-cli/NODE_WARNING`) with the following properties
    - `warningType` (e.g. `DeprecationWarning`, `UnhandledPromiseRejectionWarning`)
    - `plugin`
    - `plugin_version`
    - `command`
    - `stack`
    - `message`
    - `nodeVersion`
- Adds `nodeVersion` to all `COMMAND_EXECUTION` events
- Removes `type` property from `EVENT_EMITTER_WARNING` event so that it actually gets sent to app insights

### Work Item
@W-8667817@