### PR TITLE
feat: add nut test to telemetry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ parameters:
     default: ''
     type: string
   repo_tag:
-    description: 'The tag of the module repo to checkout, '''' defaults to branch/PR'
+    description: "The tag of the module repo to checkout, '' defaults to branch/PR"
     default: ''
     type: string
 workflows:
@@ -56,6 +56,19 @@ workflows:
                 node_version: lts
               - os: windows
                 node_version: maintenance
+      - release-management/test-nut:
+          context:
+            - << pipeline.parameters.nut_context >>
+          name: nuts-on-linux
+          sfdx_version: latest
+          requires:
+            - release-management/test-package
+      - release-management/test-nut:
+          name: nuts-on-windows
+          sfdx_version: latest
+          os: windows
+          requires:
+            - release-management/test-package
       - release-management/release-package:
           sign: true
           github-release: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,6 @@ workflows:
               - os: windows
                 node_version: maintenance
       - release-management/test-nut:
-          context:
-            - << pipeline.parameters.nut_context >>
           name: nuts-on-linux
           sfdx_version: latest
           requires:

--- a/test/commands/telemetry.nut.ts
+++ b/test/commands/telemetry.nut.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from 'chai';
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { getString } from '@salesforce/ts-types';
+import { fs } from '@salesforce/core';
+
+export interface ListApiDisplayOutput {
+  status: number;
+  result: Array<Record<string, unknown>>;
+}
+
+describe('telemetry', () => {
+  let testSession: TestSession;
+
+  before('prepare session and ensure environment variables', () => {
+    testSession = TestSession.create({});
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+
+  it('should enable the telemetry', () => {
+    const command = 'telemetry';
+    const result = execCmd(command, { ensureExitCode: 0 });
+    const output = getString(result, 'shellOutput.stdout').split('\n');
+    const tempDir = output[1].split(' ').slice(-1).pop().slice(0, -1);
+    const cacheDir = output[2].split(' ').slice(-1).pop().slice(0, -1);
+    expect(fs.existsSync(tempDir)).to.be.true;
+    expect(fs.existsSync(cacheDir)).to.be.true;
+    expect(output[0]).to.include('Telemetry is enabled');
+  });
+});

--- a/test/commands/telemetry.nut.ts
+++ b/test/commands/telemetry.nut.ts
@@ -9,11 +9,6 @@ import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { getString } from '@salesforce/ts-types';
 import { fs } from '@salesforce/core';
 
-export interface ListApiDisplayOutput {
-  status: number;
-  result: Array<Record<string, unknown>>;
-}
-
 describe('telemetry', () => {
   let testSession: TestSession;
 


### PR DESCRIPTION
### What does this PR do?
Adds a simple telemetry command tests it also looks for the temporal and cache folders it creates

### What issues does this PR fix or reference?
@W-9167844@