### PR TITLE
fix: leave org as undefined when trying to determine its type

### DIFF
--- a/src/hooks/telemetryPrerun.ts
+++ b/src/hooks/telemetryPrerun.ts
@@ -93,14 +93,16 @@ const hook: Hook.Prerun = async function (options: Hooks['prerun']): Promise<voi
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async (cmdErr: SfdxError, _, org?: Org): Promise<void> => {
         const apiVersion = org ? org.getConnection().getApiVersion() : undefined;
-        let orgType: string | undefined = org && (await org.determineIfDevHubOrg()) ? 'devhub' : undefined;
-        if (!orgType && org) {
-          try {
+        let orgType: string | undefined;
+
+        try {
+          orgType = org && (await org.determineIfDevHubOrg()) ? 'devhub' : undefined;
+          if (!orgType && org) {
             await org.checkScratchOrg();
             orgType = 'scratch';
-          } catch (err) {
-            /* Leave the org as unknown for app insights */
           }
+        } catch (err) {
+          /* leave the org as unknown for app insights */
         }
 
         // Telemetry will scrub the exception

--- a/test/hooks/telemetryPrerun.test.ts
+++ b/test/hooks/telemetryPrerun.test.ts
@@ -216,5 +216,29 @@ describe('telemetry prerun hook', () => {
       expect(recordStub.called).to.equal(false);
       expect(uploadStub.called).to.equal(false);
     });
+
+    it('calls recordError on cmdError when failing to determine org type', async () => {
+      await hook.call(context, args);
+
+      expect(createCommandStub.called).to.equal(true);
+      expect(processExitStub.called).to.equal(true);
+      expect(processCmdErrorStub.called).to.equal(true);
+
+      await processCmdErrorStub.firstCall.args[1](
+        new SfdxError('test'),
+        {},
+        {
+          determineIfDevHubOrg: async () => Promise.reject(new Error()),
+          checkScratchOrg: async () => {},
+          getConnection: () => ({ getApiVersion: () => '47.0' }),
+        }
+      );
+
+      expect(recordErrorStub.called).to.equal(true);
+      expect(recordErrorStub.firstCall.args[1].orgType).to.equal(undefined);
+
+      expect(recordStub.called).to.equal(false);
+      expect(uploadStub.called).to.equal(false);
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Moves `await org.determineIfDevHubOrg()` inside a try-catch block. If the prerun hook fails to determine if the org is a devhub or not, just leave it as undefined (that's the case when trying to determine if its a scratch org).


### What issues does this PR fix or reference?
@W-9995843@