### PR TITLE
fix: improve flag capture

### DIFF
--- a/src/commandExecution.ts
+++ b/src/commandExecution.ts
@@ -194,12 +194,14 @@ export class CommandExecution extends AsyncCreatable {
 
           let possibleAliases = flagDefinitions[flagName].aliases ?? [];
 
+          // charAliases is optional
+          // this check also ensure compatibility with commands using oclif/core < 3 where `charAliases` isn't supported.
           if (flagDefinitions[flagName].charAliases) {
             possibleAliases = possibleAliases?.concat(flagDefinitions[flagName].charAliases as string[]);
           }
 
           // if you have a flag that sets a default value and has aliases
-          // this check will ensure it only gets captured if the user specified using aliases
+          // this check will ensure it only gets captured if the user specified it using aliases
           const specifiedFlag = possibleAliases.find((a) => argvFlags.includes(a));
 
           if (specifiedFlag) {

--- a/test/helpers/myCommand.ts
+++ b/test/helpers/myCommand.ts
@@ -17,6 +17,18 @@ export class MyCommand extends SfCommand<void> {
     test: Flags.string({ char: 't' }),
     valid: Flags.string({ aliases: ['invalid', 'i'], char: 'v', deprecateAliases: true }),
     newflag: Flags.string({ aliases: ['oldflag', 'o'], char: 'n', deprecateAliases: true }),
+    user: Flags.string({
+      aliases: ['targetuser'],
+      deprecateAliases: true,
+      default: async () => 'test',
+    }),
+    blue: Flags.string({
+      aliases: ['bleu'],
+    }),
+    red: Flags.string({
+      charAliases: ['e'],
+      char: 'r',
+    }),
   };
   public static args = {};
 


### PR DESCRIPTION
Improve how flags are captured for telemetry.

Bug fixes:
1. capture flags with default values only if the user specified them

Example:
`--target-org` flag has a default fn set to grab the current target org from config if user doesn't specify it:
https://github.com/salesforcecli/sf-plugins-core/blob/5f83f922ac924ef7b87aa92d92c62dd6a99aabe8/src/flags/orgFlags.ts#L142

so if you run `sf org open --url-only` then telemetry will get this:
```
...
 "specifiedFlags": "target-org url-only",
  "specifiedFlagFullNames": "target-org url-only",
  "deprecatedFlagsUsed": ""
...
```

`specifiedFlags` and `specifiedFlagFullNames` should only contain flags that the user typed.

repro:
set a default target org with `sf config set`, then run:
```
DEBUG=sf:telemetry SF_DISABLE_TELEMETRY=false SF_TELEMETRY_DEBUG=true sf org open --url-only
```

and open the `telemetry-********.log` file shown in debug logs to see the payload.

2. capture flags if using its non-deprecated alias

Example:

`sobject describe` tooling api flag:
https://github.com/salesforcecli/plugin-schema/blob/dec04b4a6e96745463361f2fb9f08c61793c407c/src/commands/sobject/describe.ts#L39-L44

`--use-tooling-api` has a non-deprecated alias `usetoolingapi`, if you use it it doesn't get captured in telemetry:

```
DEBUG=*telemetry* SF_DISABLE_TELEMETRY=false SF_TELEMETRY_DEBUG=true sf sobject describe --sobject Account --usetoolingapi
```

then open the file, you'll see:

```
  "command": "sobject:describe",
  "specifiedFlags": "target-org sobject",
  "specifiedFlagFullNames": "target-org sobject",
  "deprecatedFlagsUsed": ""
```

3. capture flag if used non-deprecated char alias:
found this while going through possible scenarios, for a flag:
```
red: Flags.string({
      charAliases: ['e'],
      char: 'r',
    })
```

if you specify it as `-e` it wouldn't get captured in telemetry. added test for it.

The first commit adds the failing test cases (you can see those failed before the fix).

## how to QA:
you can follow the examples 1 and 2 using `sf` to verify the current behaviour, then checkout this locally, link plugin-telemetry and run examples again.

@W-14441156@