### PR TITLE
feat: capture error codes

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -180,7 +180,7 @@ export default class Telemetry extends AsyncCreatable {
     }
   }
 
-  public recordError(error: Error, data: JsonMap): void {
+  public recordError(error: NodeJS.ErrnoException, data: JsonMap): void {
     data.type = Telemetry.EXCEPTION;
     // Also have on custom attributes since app insights might parse differently
     data.errorName = error.name;
@@ -190,6 +190,7 @@ export default class Telemetry extends AsyncCreatable {
         name: error.name,
         message: error.message,
         stack: error.stack,
+        code: error.code ?? '',
       } as JsonMap,
       error
     );


### PR DESCRIPTION
Exceptions will include `error.code` if the failure was caused by a system error like a network connection, fs operation failure, etc.

https://nodejs.org/docs/latest/api/errors.html#class-systemerror

I'm adding this specifically to filter network errors by code in telemetry instead of having to compare strings in error messages.

See: https://salesforce-internal.slack.com/archives/G02K6C90RBJ/p1710431639322819

@W-15451832@