### PR TITLE
feat: export telemetryGlobal type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@
  */
 
 export * from './telemetry.js';
+export type { TelemetryGlobal } from './telemetryGlobal.js';


### PR DESCRIPTION
while trying to update plugin-telemetry in plugin-trust (it's on a really old version), we get an error about illegal imports

see https://github.com/salesforcecli/plugin-trust/blob/9357ae5a7723daa260d91427d39f7ad43d86f03f/src/hooks/jitPluginInstall.ts#L10

export that type so that plugin-trust can use it cleanly

[skip-validate-pr

