### PR TITLE
fix: add proxy envs to telemetry

### DIFF
--- a/src/gatherEnvs.ts
+++ b/src/gatherEnvs.ts
@@ -19,7 +19,11 @@ const isOurEnv = (key: string): boolean =>
   key.startsWith('JSFORCE_') ||
   key === 'FORCE_OPEN_URL' ||
   key === 'FORCE_SHOW_SPINNER' ||
-  key === 'FORCE_SPINNER_DELAY';
+  key === 'FORCE_SPINNER_DELAY' ||
+  key === 'HTTPS_PROXY' ||
+  key === 'HTTP_PROXY' ||
+  key === 'https_proxy' ||
+  key === 'http_proxy';
 
 /** we do some automatic SFDX => SF and we don't want 2 of all of those  */
 const isNotDuplicatedAcrossCLIs = (key: string, index: number, array: string[]): boolean =>

--- a/test/gatherEnvs.test.ts
+++ b/test/gatherEnvs.test.ts
@@ -10,7 +10,7 @@ import { getRelevantEnvs } from '../src/gatherEnvs.js';
 
 const testEnvs = ['SF_TEST', 'SFDX_TEST', 'SF_TEST2', 'OTHER_ENV'];
 describe('gatherEnvs', () => {
-  beforeEach(() => {
+  afterEach(() => {
     testEnvs.map((env) => delete process.env[env]);
   });
 
@@ -41,5 +41,57 @@ describe('gatherEnvs', () => {
   it('returns no irrelevant envs', () => {
     process.env.OTHER_ENV = 'test';
     expect(getRelevantEnvs()).to.deep.equal({ specifiedEnvs: [], uniqueEnvs: [] });
+  });
+
+  describe('for proxies', () => {
+    const proxyEnvs = ['HTTPS_PROXY', 'HTTP_PROXY', 'https_proxy', 'http_proxy'];
+
+    afterEach(() => {
+      proxyEnvs.map((env) => delete process.env[env]);
+    });
+
+    it('returns HTTPS env', () => {
+      process.env.HTTPS_PROXY = 'HTTPS-test';
+      expect(getRelevantEnvs()).to.deep.equal({ specifiedEnvs: ['HTTPS_PROXY'], uniqueEnvs: ['HTTPS_PROXY'] });
+    });
+
+    it('returns HTTP env', () => {
+      process.env.HTTP_PROXY = 'HTTP-test';
+      expect(getRelevantEnvs()).to.deep.equal({ specifiedEnvs: ['HTTP_PROXY'], uniqueEnvs: ['HTTP_PROXY'] });
+    });
+
+    it('returns HTTPS and HTTP env', () => {
+      process.env.HTTPS_PROXY = 'HTTPS-test';
+      process.env.HTTP_PROXY = 'HTTP-test';
+      expect(getRelevantEnvs()).to.deep.equal({
+        specifiedEnvs: ['HTTPS_PROXY', 'HTTP_PROXY'],
+        uniqueEnvs: ['HTTPS_PROXY', 'HTTP_PROXY'],
+      });
+    });
+
+    it('returns https env', () => {
+      // eslint-disable-next-line camelcase
+      process.env.https_proxy = 'https-test';
+      expect(getRelevantEnvs()).to.deep.equal({ specifiedEnvs: ['https_proxy'], uniqueEnvs: ['https_proxy'] });
+    });
+
+    it('returns http env', () => {
+      // eslint-disable-next-line camelcase
+      process.env.http_proxy = 'http-test';
+      expect(getRelevantEnvs()).to.deep.equal({ specifiedEnvs: ['http_proxy'], uniqueEnvs: ['http_proxy'] });
+    });
+
+    it('returns HTTPS, HTTP, https, http env', () => {
+      process.env.HTTPS_PROXY = 'HTTPS-test';
+      process.env.HTTP_PROXY = 'HTTP-test';
+      // eslint-disable-next-line camelcase
+      process.env.https_proxy = 'https-test';
+      // eslint-disable-next-line camelcase
+      process.env.http_proxy = 'http-test';
+      expect(getRelevantEnvs()).to.deep.equal({
+        specifiedEnvs: ['HTTPS_PROXY', 'HTTP_PROXY', 'http_proxy', 'https_proxy'],
+        uniqueEnvs: ['HTTPS_PROXY', 'HTTP_PROXY', 'http_proxy', 'https_proxy'],
+      });
+    });
   });
 });


### PR DESCRIPTION
Adds https_proxy, http_proxy, HTTPS_PROXY, and HTTP_PROXY env vars to plugin-telemetry

@W-16287897@