### PR TITLE
fix: add agent psuedo type telemetry W-17247028

### DIFF
--- a/src/commandExecution.ts
+++ b/src/commandExecution.ts
@@ -36,6 +36,7 @@ export class CommandExecution extends AsyncCreatable {
 
   private orgId?: string | null;
   private devhubId?: string | null;
+  private agentPseudoTypeUsed?: boolean | null;
   private orgApiVersion?: string | null;
   private devhubApiVersion?: string | null;
   private argKeys: string[] = [];
@@ -81,6 +82,7 @@ export class CommandExecution extends AsyncCreatable {
       specifiedFlags: this.specifiedFlags.sort().join(' '),
       // Flags the user specified, only the full names
       specifiedFlagFullNames: this.specifiedFlagFullNames.sort().join(' '),
+      agentPseudoTypeUsed: this.agentPseudoTypeUsed ?? false,
       deprecatedFlagsUsed: this.deprecatedFlagsUsed.sort().join(' '),
       deprecatedCommandUsed: this.deprecatedCommandUsed,
       sfdxEnv: process.env.SFDX_ENV,
@@ -150,7 +152,8 @@ export class CommandExecution extends AsyncCreatable {
         strict: this.command.strict ?? !this.command.varargs,
       });
       flags = parseResult.flags;
-
+      this.agentPseudoTypeUsed =
+        (flags['metadata'] as unknown as string[])?.join().trim().toLowerCase().startsWith('agent') ?? false;
       this.argKeys = [...new Set(Object.keys(parseVarArgs(parseResult.args, parseResult.argv as string[])))];
     } catch (error) {
       debug('Error parsing flags');

--- a/src/commandExecution.ts
+++ b/src/commandExecution.ts
@@ -153,7 +153,8 @@ export class CommandExecution extends AsyncCreatable {
       });
       flags = parseResult.flags;
       this.agentPseudoTypeUsed =
-        (flags['metadata'] as unknown as string[])?.join().trim().toLowerCase().startsWith('agent') ?? false;
+        (flags['metadata'] as unknown as string[])?.some((metadata) => metadata.toLowerCase().startsWith('agent')) ??
+        false;
       this.argKeys = [...new Set(Object.keys(parseVarArgs(parseResult.args, parseResult.argv as string[])))];
     } catch (error) {
       debug('Error parsing flags');

--- a/test/commandExecution.test.ts
+++ b/test/commandExecution.test.ts
@@ -80,6 +80,47 @@ describe('toJson', () => {
     expect(actual.specifiedFlagFullNames).to.equal('flag valid');
   });
 
+  it('calculated Agent MD used', async () => {
+    process.env.CI = 'true';
+    const config = stubInterface<Interfaces.Config>(sandbox, {});
+    const execution1 = await CommandExecution.create({
+      argv: ['-m', 'Agent:my'],
+      command: MyCommand,
+      config,
+    });
+    const actual1 = execution1.toJson();
+    expect(actual1.agentPseudoTypeUsed).to.be.true;
+    // long flag
+    const execution2 = await CommandExecution.create({
+      argv: ['--metadata', 'Agent:my'],
+      command: MyCommand,
+      config,
+    });
+    const actual2 = execution2.toJson();
+
+    expect(actual2.agentPseudoTypeUsed).to.be.true;
+
+    // no flag = false
+    const execution3 = await CommandExecution.create({
+      argv: [''],
+      command: MyCommand,
+      config,
+    });
+    const actual3 = execution3.toJson();
+
+    expect(actual3.agentPseudoTypeUsed).to.be.false;
+
+    // value = false
+    const execution4 = await CommandExecution.create({
+      argv: ['--metadata', 'ApexClass:myAgent'],
+      command: MyCommand,
+      config,
+    });
+    const actual4 = execution4.toJson();
+
+    expect(actual4.agentPseudoTypeUsed).to.be.false;
+  });
+
   it('shows multiple deprecated chars as chars', async () => {
     process.env.CI = 'true';
     const config = stubInterface<Interfaces.Config>(sandbox, {});

--- a/test/commandExecution.test.ts
+++ b/test/commandExecution.test.ts
@@ -119,6 +119,16 @@ describe('toJson', () => {
     const actual4 = execution4.toJson();
 
     expect(actual4.agentPseudoTypeUsed).to.be.false;
+
+    // agent used second
+    const execution5 = await CommandExecution.create({
+      argv: ['--metadata', 'ApexClass:myAgent', '--metadata', 'Agent'],
+      command: MyCommand,
+      config,
+    });
+    const actual5 = execution5.toJson();
+
+    expect(actual5.agentPseudoTypeUsed).to.be.true;
   });
 
   it('shows multiple deprecated chars as chars', async () => {

--- a/test/helpers/myCommand.ts
+++ b/test/helpers/myCommand.ts
@@ -29,6 +29,10 @@ export class MyCommand extends SfCommand<void> {
       charAliases: ['e'],
       char: 'r',
     }),
+    metadata: Flags.string({
+      char: 'm',
+      multiple: true,
+    }),
   };
   public static args = {};
 


### PR DESCRIPTION
@W-17247028@

adds a telemetry key, `agentPseudoTypeUsed` when `--metadata Agent` used